### PR TITLE
fix(message register): register basic.ack and basic.publish extended …

### DIFF
--- a/Test.It.With.RabbitMQ.091/Methods/Confirm.cs
+++ b/Test.It.With.RabbitMQ.091/Methods/Confirm.cs
@@ -10,8 +10,8 @@ namespace Test.It.With.RabbitMQ091.Methods
         public class Select : IRespond<SelectOk>, IClientMethod
         {
             internal const int MethodId = 10;
-            public int ProtocolClassId { get; } = ClassId;
-            public int ProtocolMethodId { get; } = MethodId;
+            public int ProtocolClassId => ClassId;
+            public int ProtocolMethodId => MethodId;
 
             public bool Nowait { get; set; }
 
@@ -44,8 +44,8 @@ namespace Test.It.With.RabbitMQ091.Methods
         public class SelectOk : IServerMethod, INonContentMethod
         {
             internal const int MethodId = 11;
-            public int ProtocolClassId { get; } = ClassId;
-            public int ProtocolMethodId { get; } = MethodId;
+            public int ProtocolClassId => ClassId;
+            public int ProtocolMethodId => MethodId;
 
             public bool SentOnValidChannel(int channel)
             {
@@ -64,7 +64,7 @@ namespace Test.It.With.RabbitMQ091.Methods
 
             public Type[] Responses()
             {
-                return new Type[0];
+                return Type.EmptyTypes;
             }
         }
     }

--- a/Test.It.With.RabbitMQ.091/RabbitMq091ProtocolExtensions.cs
+++ b/Test.It.With.RabbitMQ.091/RabbitMq091ProtocolExtensions.cs
@@ -12,7 +12,7 @@ namespace Test.It.With.RabbitMQ091
             method = default;
 
             var classId = reader.ReadShortUnsignedInteger();
-            if (_classRegister.TryGetValue(classId, out var methodRegister) == false)
+            if (ClassRegister.TryGetValue(classId, out var methodRegister) == false)
             {
                 return false;
             }
@@ -28,14 +28,16 @@ namespace Test.It.With.RabbitMQ091
             return true;
         }
 
-        private readonly Dictionary<int, Dictionary<int, Func<IMethod>>> _classRegister = new Dictionary<int, Dictionary<int, Func<IMethod>>>
+        private static readonly Dictionary<int, Dictionary<int, Func<IMethod>>> ClassRegister = new Dictionary<int, Dictionary<int, Func<IMethod>>>
         {
             { Confirm.ClassId, new Dictionary<int, Func<IMethod>> {
                 { Confirm.Select.MethodId, () => new Confirm.Select() },
                 { Confirm.SelectOk.MethodId, () => new Confirm.SelectOk() }}},
             { Basic.ClassId, new Dictionary<int, Func<IMethod>>
             {
-                { Basic.Nack.MethodId, () => new Basic.Nack() }
+                { Basic.Nack.MethodId, () => new Basic.Nack() },
+                { new Basic.Ack().ProtocolMethodId, () => new Basic.Ack() },
+                { new Basic.Publish().ProtocolMethodId, () => new Basic.Publish() }
             }}
         };
     }

--- a/Tests/Test.It.With.RabbitMQ.091.Integration.Tests/When_publishing_a_message_and_waiting_for_confirm.cs
+++ b/Tests/Test.It.With.RabbitMQ.091.Integration.Tests/When_publishing_a_message_and_waiting_for_confirm.cs
@@ -29,8 +29,8 @@ namespace Test.It.With.RabbitMQ091.Integration.Tests
             private readonly ConcurrentBag<MethodFrame<Exchange.Declare>> _exchangeDeclare =
                 new ConcurrentBag<MethodFrame<Exchange.Declare>>();
 
-            private readonly ConcurrentBag<MethodFrame<Amqp091.Protocol.Basic.Publish>> _basicPublish =
-                new ConcurrentBag<MethodFrame<Amqp091.Protocol.Basic.Publish>>();
+            private readonly ConcurrentBag<MethodFrame<Basic.Publish>> _basicPublish =
+                new ConcurrentBag<MethodFrame<Basic.Publish>>();
 
             private bool _selectOkSent;
 
@@ -75,7 +75,7 @@ namespace Test.It.With.RabbitMQ091.Integration.Tests
                     channelClosed = true;
                     TryStop();
                 });
-                testServer.On<Amqp091.Protocol.Basic.Publish>((connectionId, frame) =>
+                testServer.On<Basic.Publish>((connectionId, frame) =>
                 {
                     _basicPublish.Add(frame);
                     testServer.Send(connectionId,


### PR DESCRIPTION
…message definitions in order to be able to subscribe to them in the test framework